### PR TITLE
support parse field 'source' and support multiple host like kafka dsn 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/kos-v/dsnparser
 
 go 1.15
+
+require (
+	github.com/gorilla/schema v1.2.1 // indirect
+	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/gorilla/schema v1.2.1 h1:tjDxcmdb+siIqkTNoV+qRH2mjYdr2hHe5MKXbp61ziM=
+github.com/gorilla/schema v1.2.1/go.mod h1:Dg5SSm5PV60mhF2NFaTV1xuYYj8tV8NOPRo4FggUMnM=
+gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
+gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=

--- a/params.go
+++ b/params.go
@@ -1,0 +1,24 @@
+package dsnparser
+
+import (
+	"net/url"
+
+	"github.com/gorilla/schema"
+)
+
+var decoder = schema.NewDecoder()
+
+// DecodeParams decode params url into a struct
+func (d *DSN) DecodeParams(value interface{}) error {
+	var err error
+	urlval := url.Values{}
+	for k, v := range d.params {
+		urlval.Add(k, v)
+	}
+	err = decoder.Decode(value, urlval)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/params_test.go
+++ b/params_test.go
@@ -1,0 +1,66 @@
+package dsnparser
+
+import (
+	"fmt"
+	"testing"
+
+	"gopkg.in/go-playground/assert.v1"
+)
+
+type ParamOption struct {
+	Tblsprefix string
+	Charset    string
+	ParseTime  bool
+	Loc        string
+	Topic      []string
+	Version    string
+}
+
+func TestDecodeMapToStruct(t *testing.T) {
+
+	var err error
+	var testcases = []struct {
+		dsn       string
+		param     ParamOption
+		wantError bool
+	}{
+		{
+			dsn: "mysql://user:password@tcp(example.com:3306)/dbname?tblsprefix=fs_",
+			param: ParamOption{
+				Tblsprefix: "fs_",
+			},
+			wantError: false,
+		},
+		{
+			dsn: "mysql://user:password@tcp(example.com:3306)/dbname?tblsprefix=fs_&charset=utf8mb4&parseTime=True&loc=Local",
+			param: ParamOption{
+				Tblsprefix: "fs_",
+				Charset:    "utf8mb4",
+				ParseTime:  true,
+				Loc:        "Local",
+			},
+			wantError: false,
+		},
+		{
+			dsn: "kafka://username:pasword@tcp(ip1:9093,ip2:9093,ip3:9093)/?topic=vsulblog&version=1.1.1",
+			param: ParamOption{
+				Topic:   []string{"vsulblog"},
+				Version: "1.1.1",
+			},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range testcases {
+		var res = ParamOption{}
+		dsn := Parse(tt.dsn)
+		err = dsn.DecodeParams(&res)
+		fmt.Println(err)
+		assert.Equal(t, err != nil, tt.wantError)
+		if err != nil {
+			continue
+		}
+		assert.Equal(t, res, tt.param)
+	}
+
+}

--- a/params_test.go
+++ b/params_test.go
@@ -58,6 +58,7 @@ func TestDecodeMapToStruct(t *testing.T) {
 		fmt.Println(err)
 		assert.Equal(t, err != nil, tt.wantError)
 		if err != nil {
+			fmt.Println(err)
 			continue
 		}
 		assert.Equal(t, res, tt.param)

--- a/parser.go
+++ b/parser.go
@@ -2,14 +2,14 @@ package dsnparser
 
 // DSN container for data after dsn parsing.
 type DSN struct {
-	raw    string
-	scheme string
-	// dsn source : dsn without schema
-	source    string
+	raw       string
+	scheme    string
+	source    string // dsn source : dsn without schema
 	user      string
 	password  string
 	host      string
 	port      string
+	hostport  string
 	path      string
 	params    map[string]string
 	transport string
@@ -18,6 +18,11 @@ type DSN struct {
 // GetHost returns a host as the string.
 func (d *DSN) GetHost() string {
 	return d.host
+}
+
+// GetHostPort returns a hostport as the string.
+func (d *DSN) GetHostPort() string {
+	return d.hostport
 }
 
 // GetParam returns an additional parameter by key as the string.
@@ -148,14 +153,12 @@ func Parse(raw string) *DSN {
 		break
 	}
 
-	multihost := false
+	// multihost := false
 	// Host and port parsing
 	for dsnPos, dsnSymbol := range dsn {
 		endPos := -1
 		if dsnSymbol == '/' {
 			endPos = dsnPos
-		} else if dsnSymbol == ',' {
-			multihost = true
 		} else if dsnPos == len(dsn)-1 {
 			endPos = len(dsn)
 		}
@@ -164,23 +167,19 @@ func Parse(raw string) *DSN {
 		}
 		hostPort := dsn[0:endPos]
 
-		if multihost {
-			d.host = string(hostPort)
-		} else {
-
-			hasSeparator := false
-			for hpPos, hpSymbol := range hostPort {
-				if hpSymbol == ':' {
-					hasSeparator = true
-					d.host = string(hostPort[0:hpPos])
-					d.port = string(hostPort[hpPos+1:])
-					break
-				}
-			}
-			if !hasSeparator {
-				d.host = string(hostPort)
+		hasSeparator := false
+		for hpPos, hpSymbol := range hostPort {
+			if hpSymbol == ':' {
+				hasSeparator = true
+				d.host = string(hostPort[0:hpPos])
+				d.port = string(hostPort[hpPos+1:])
+				break
 			}
 		}
+		if !hasSeparator {
+			d.host = string(hostPort)
+		}
+		d.hostport = string(hostPort)
 
 		dsn = dsn[dsnPos+1:]
 		break

--- a/parser.go
+++ b/parser.go
@@ -2,22 +2,22 @@ package dsnparser
 
 // DSN container for data after dsn parsing.
 type DSN struct {
-	Raw    string
-	Scheme string
+	raw    string
+	scheme string
 	// dsn source : dsn without schema
-	Source    string
-	User      string
-	Password  string
-	Host      string
-	Port      string
-	Path      string
-	Params    map[string]string
-	Transport string
+	source    string
+	user      string
+	password  string
+	host      string
+	port      string
+	path      string
+	params    map[string]string
+	transport string
 }
 
 // GetHost returns a host as the string.
 func (d *DSN) GetHost() string {
-	return d.Host
+	return d.host
 }
 
 // GetParam returns an additional parameter by key as the string.
@@ -25,17 +25,17 @@ func (d *DSN) GetParam(key string) string {
 	if !d.HasParam(key) {
 		return ""
 	}
-	return d.Params[key]
+	return d.params[key]
 }
 
 // GetParams returns additional parameters as key-value map.
 func (d *DSN) GetParams() map[string]string {
-	return d.Params
+	return d.params
 }
 
 // HasParam checks for the existence of an additional parameter.
 func (d *DSN) HasParam(key string) bool {
-	if _, ok := d.Params[key]; ok {
+	if _, ok := d.params[key]; ok {
 		return true
 	}
 	return false
@@ -43,60 +43,60 @@ func (d *DSN) HasParam(key string) bool {
 
 // GetPassword returns a credential password as the string.
 func (d *DSN) GetPassword() string {
-	return d.Password
+	return d.password
 }
 
 // GetPath returns a path as the string.
 func (d *DSN) GetPath() string {
-	return d.Path
+	return d.path
 }
 
 // GetPort returns a port as the string.
 func (d *DSN) GetPort() string {
-	return d.Port
+	return d.port
 }
 
 // GetRaw returns the dsn in its raw form, as it was passed to the Parse function.
 func (d *DSN) GetRaw() string {
-	return d.Raw
+	return d.raw
 }
 
 // GetScheme returns a scheme as the string.
 func (d *DSN) GetScheme() string {
-	return d.Scheme
+	return d.scheme
 }
 
 // GetTransport returns a transport as the string.
 func (d *DSN) GetTransport() string {
-	return d.Transport
+	return d.transport
 }
 
 // GetUser returns a credential user as the string.
 func (d *DSN) GetUser() string {
-	return d.User
+	return d.user
 }
 
 // GetSource returns a dsn source  user as the string.
 func (d *DSN) GetSource() string {
-	return d.User
+	return d.source
 }
 
 // Parse receives a raw dsn as argument, parses it and returns it in the DSN structure.
 func Parse(raw string) *DSN {
 	d := DSN{
-		Raw:    raw,
-		Source: raw,
-		Params: map[string]string{},
+		raw:    raw,
+		source: raw,
+		params: map[string]string{},
 	}
-	dsn := []rune(d.Raw)
+	dsn := []rune(d.raw)
 
 	// Parsing the scheme
 	for pos, symbol := range dsn {
 		// Found end of the scheme name
 		if symbol == '/' && pos > 2 && string(dsn[pos-2:pos+1]) == "://" {
-			d.Scheme = string(dsn[0 : pos-2])
+			d.scheme = string(dsn[0 : pos-2])
 			dsn = dsn[pos+1:]
-			d.Source = string(dsn)
+			d.source = string(dsn)
 			break
 		}
 	}
@@ -112,13 +112,13 @@ func Parse(raw string) *DSN {
 			for credPos, credChar := range credentials {
 				if credChar == ':' && !isEscaped(credPos, credentials) {
 					hasSeparator = true
-					d.User = string(unEscape([]rune{':', '@'}, credentials[0:credPos]))
-					d.Password = string(unEscape([]rune{':', '@'}, credentials[credPos+1:]))
+					d.user = string(unEscape([]rune{':', '@'}, credentials[0:credPos]))
+					d.password = string(unEscape([]rune{':', '@'}, credentials[credPos+1:]))
 					break
 				}
 			}
 			if !hasSeparator {
-				d.User = string(unEscape([]rune{':', '@'}, credentials))
+				d.user = string(unEscape([]rune{':', '@'}, credentials))
 			}
 
 			dsn = dsn[dsnPos+1:]
@@ -143,7 +143,7 @@ func Parse(raw string) *DSN {
 			continue
 		}
 
-		d.Transport = string(dsn[:hpExtractBeginPos-1])
+		d.transport = string(dsn[:hpExtractBeginPos-1])
 		dsn = append(dsn[hpExtractBeginPos:hpExtractEndPos+1], dsn[hpExtractEndPos+2:]...)
 		break
 	}
@@ -165,20 +165,20 @@ func Parse(raw string) *DSN {
 		hostPort := dsn[0:endPos]
 
 		if multihost {
-			d.Host = string(hostPort)
+			d.host = string(hostPort)
 		} else {
 
 			hasSeparator := false
 			for hpPos, hpSymbol := range hostPort {
 				if hpSymbol == ':' {
 					hasSeparator = true
-					d.Host = string(hostPort[0:hpPos])
-					d.Port = string(hostPort[hpPos+1:])
+					d.host = string(hostPort[0:hpPos])
+					d.port = string(hostPort[hpPos+1:])
 					break
 				}
 			}
 			if !hasSeparator {
-				d.Host = string(hostPort)
+				d.host = string(hostPort)
 			}
 		}
 
@@ -197,7 +197,7 @@ func Parse(raw string) *DSN {
 		}
 
 		if endPos > -1 {
-			d.Path = string(dsn[0:endPos])
+			d.path = string(dsn[0:endPos])
 			dsn = dsn[pos+1:]
 			break
 		}
@@ -233,7 +233,7 @@ func Parse(raw string) *DSN {
 			}
 
 			if len(paramKey) > 0 {
-				d.Params[string(unEscape([]rune{'=', '&'}, paramKey))] = string(unEscape([]rune{'=', '&'}, paramVal))
+				d.params[string(unEscape([]rune{'=', '&'}, paramKey))] = string(unEscape([]rune{'=', '&'}, paramVal))
 			}
 		}
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -185,13 +185,58 @@ func TestParse_Host(t *testing.T) {
 		{"mysql://user:password@хост.лок:3306", "хост.лок"},
 		{"mysql://user:password@хост.лок1", "хост.лок1"},
 		{"mysql://user:password@хост.ло1к", "хост.ло1к"},
-		{"kafka://username:pasword@tcp(ip1:9093,ip2:9093,ip3:9093)/?topic=vsulblog", "ip1:9093,ip2:9093,ip3:9093"},
+		{"kafka://username:pasword@tcp(ip1:9093,ip2:9093,ip3:9093)/?topic=vsulblog", "ip1"},
 	}
 
 	for i, test := range tests {
 		dsn := Parse(test.dsn)
 		if dsn.GetHost() != test.expected {
 			t.Errorf("Unexpected value in test \"%v\". Expected: \"%s\". Result: \"%s\"", i+1, test.expected, dsn.GetHost())
+		}
+	}
+}
+
+func TestParse_HostPort(t *testing.T) {
+	tests := []struct {
+		dsn      string
+		expected string
+	}{
+		{"mysql://user:password@example.com:3306/dbname?tblsprefix=fs_", "example.com:3306"},
+		{"mysql://user:password@tcp(example.com:3306)/dbname?tblsprefix=fs_", "example.com:3306"},
+		{"mysql://user:password@example.com/dbname?tblsprefix=fs_", "example.com"},
+		{"mysql://user:password@tcp(example.com)/dbname?tblsprefix=fs_", "example.com"},
+		{"mysql://user:password@localhost/dbname?tblsprefix=fs_", "localhost"},
+		{"mysql://user:password@127.0.0.1/dbname?tblsprefix=fs_", "127.0.0.1"},
+		{"mysql://user:password@example.com", "example.com"},
+		{"mysql://user:password@example.com:3306", "example.com:3306"},
+		{"mysql://user:password@/dbname?tblsprefix=fs_", ""},
+		{"mysql://user:password@:3306", ":3306"},
+		{"mysql://user:password@", ""},
+		{"mysql://example.loc", "example.loc"},
+		{"example.loc", "example.loc"},
+		{"example.loc:3306", "example.loc:3306"},
+		{"example.loc/path", "example.loc"},
+		{"example.loc:3306/path", "example.loc:3306"},
+		{"example.loc:/", "example.loc:"},
+		{"example", "example"},
+		{"example:3306", "example:3306"},
+		{"example/path", "example"},
+		{"example:/", "example:"},
+		{"mysql://user:password@not$valid@host/dbname?tblsprefix=fs_", "not$valid@host"},
+		{"mysql://user:password@not$valid@hostdbname?tblsprefix=fs_", "not$valid@hostdbname?tblsprefix=fs_"},
+		{"mysql://user:password@хост.лок:3306/dbname?tblsprefix=fs_", "хост.лок:3306"},
+		{"mysql://user:password@хост.лок", "хост.лок"},
+		{"mysql://user:password@хост.лок:3306/путь", "хост.лок:3306"},
+		{"mysql://user:password@хост.лок:3306", "хост.лок:3306"},
+		{"mysql://user:password@хост.лок1", "хост.лок1"},
+		{"mysql://user:password@хост.ло1к", "хост.ло1к"},
+		{"kafka://username:pasword@tcp(ip1:9093,ip2:9093,ip3:9093)/?topic=vsulblog", "ip1:9093,ip2:9093,ip3:9093"},
+	}
+
+	for i, test := range tests {
+		dsn := Parse(test.dsn)
+		if dsn.GetHostPort() != test.expected {
+			t.Errorf("Unexpected value in test \"%v\". Expected: \"%s\". Result: \"%s\"", i+1, test.expected, dsn.GetHostPort())
 		}
 	}
 }
@@ -207,7 +252,7 @@ func TestParse_Port(t *testing.T) {
 		{"mysql://user:password@tcp(example.com:3306)", "3306"},
 		{"mysql://user:password@example.com/dbname?tblsprefix=fs_", ""},
 		{"mysql://user:password@example.com:/dbname?tblsprefix=fs_", ""},
-		{"mysql://user:password@example.com:bad, but working/dbname?tblsprefix=fs_", ""},
+		{"mysql://user:password@example.com:bad, but working/dbname?tblsprefix=fs_", "bad, but working"},
 		{"example.com:3306", "3306"},
 		{"tcp(example.com:3306)", "3306"},
 		{"example.com:", ""},

--- a/parser_test.go
+++ b/parser_test.go
@@ -282,8 +282,8 @@ func TestParse_Source(t *testing.T) {
 
 	for i, test := range tests {
 		dsn := Parse(test.dsn)
-		if dsn.Source != test.expected {
-			t.Errorf("Unexpected value in test \"%v\". Expected: \"%s\". Result: \"%s\"", i+1, test.expected, dsn.Source)
+		if dsn.GetSource() != test.expected {
+			t.Errorf("Unexpected value in test \"%v\". Expected: \"%s\". Result: \"%s\"", i+1, test.expected, dsn.GetSource())
 		}
 	}
 }


### PR DESCRIPTION
1. support parse field 'source', dsn data without schema,  for many orm like "gorm" 'xorm' . 
e.g :
dsn : "mysql://user:password@tcp(example.com:3306)/foo?tblsprefix=fs_"
source : "user:password@tcp(example.com:3306)/foo?tblsprefix=fs_"

2. support parse multiple host , like kafka dsn .
dns  :  "kafka://username:pasword@tcp(ip1:9093,ip2:9093,ip3:9093)/?topic=vsulblog"
host : "ip1:9093,ip2:9093,ip3:9093"